### PR TITLE
SCRUM-181_OrderFilters

### DIFF
--- a/src/components/kitchen/OrderDetails.js
+++ b/src/components/kitchen/OrderDetails.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from 'primereact/button';
 import { Card } from 'primereact/card';
+import style from 'styled-jsx/style';
 
 const imageMapping = {
   'Onigiris de Atún': 'https://images.pond5.com/pixel-sushi-vector-illustration-isolated-illustration-155825087_iconm.jpeg',
@@ -44,7 +45,7 @@ export default function OrderDetails({ order, onConfirmComplete }) {
         !showDetails ? <p>La orden ha sido completada.</p> : <p>No hay platos en este pedido.</p>
       )}
 
-      {showDetails && order.orderItems && order.orderItems.length > 0 && (
+      {showDetails && order.orderItems && order.orderItems.length > 0 && order.orderStatus === 'Pendiente' && (
         <div style={styles.statusContainer}>
           <Button
             onClick={handleConfirmCompleteOrder}

--- a/src/pages/kitchen/order.js
+++ b/src/pages/kitchen/order.js
@@ -7,6 +7,9 @@ import { Button } from 'primereact/button';
 import { Card } from 'primereact/card';
 import { Toast } from 'primereact/toast';
 import { ConfirmDialog, confirmDialog } from 'primereact/confirmdialog';
+import { Calendar } from 'primereact/calendar';
+import { RadioButton } from 'primereact/radiobutton';
+import { Dropdown } from 'primereact/dropdown';
 
 import OrderService from '@/service/OrderService';
 import withAuth from '@/components/misc/WithAuth';
@@ -20,6 +23,10 @@ function OrdersPage() {
     const [loading, setLoading] = useState(false);  // Control de carga
     const [error, setError] = useState(null);  // Almacena el error si ocurre
     const [isLastPage, setIsLastPage] = useState(false);  // Bandera para saber si estamos en la última página
+    const [dates, setDates] = useState(null);  // Almacena las fechas seleccionadas
+    const [status, setStatus] = useState('Pendiente'); 
+    const [selectedItem, setSelectedItem] = useState(null);
+    const items = [ {name: 'Ascendente', code: 'true'}, {name: 'Descendente', code: 'false'}];
     let pollingInterval = null;  // Variable para almacenar el intervalo del polling
 
     const orderService = new OrderService(); 
@@ -48,8 +55,8 @@ function OrdersPage() {
     const loadOrders = async (pageNumber) => {
         setLoading(true);
         try {
-            // const data = await orderService.getOrders(pageNumber, rows);
-            const data = await orderService.getOrdersByStatus('Pendiente',pageNumber); 
+            console.log('status:', status);
+            const data = await orderService.getOrdersByStatus(status, pageNumber); 
             // Evitar re-renderizar si no hay cambios en los datos
             if (JSON.stringify(data.content) !== JSON.stringify(orders)) {
                 setOrders(data.content);  // Solo actualizar si los datos son diferentes
@@ -191,7 +198,29 @@ function OrdersPage() {
                         <Card title="Ordenes"></Card>
                             <br />
                         {error && <p style={{ color: 'red' }}>{error}</p>}
-
+                        
+                        <Card className="flex align-items-center gap-2 mb-3">
+                            <div style={styles.filterContainer} >
+                                <div style={styles.statusGroup}>
+                                    <div className="flex align-items-center">
+                                        <RadioButton inputId="status1" name="orderStatus" value="Pendiente" onChange={(e) => setStatus(e.value)} checked={status === 'Pendiente'} />
+                                        <label htmlFor="status1" className="ml-2">Pendiente</label>
+                                    </div>
+                                    <div className="flex align-items-center">
+                                        <RadioButton inputId="status2" name="orderStatus" value="Entregado" onChange={(e) => setStatus(e.value)} checked={status === 'Entregado'} />
+                                        <label htmlFor="status2" className="ml-2">Entregado</label>
+                                    </div>
+                                    <div className="flex align-items-center">
+                                        <RadioButton inputId="status3" name="orderStatus" value="Cancelado" onChange={(e) => setStatus(e.value)} checked={status === 'Cancelado'} />
+                                        <label htmlFor="status3" className="ml-2">Cancelado</label>
+                                    </div>
+                                    
+                                </div>
+                                <Calendar value={dates} onChange={(e) => setDates(e.value)} placeholder="Rango de Fecha" selectionMode="range" dateFormat='yy/mm/dd'readOnlyInput hideOnRangeSelection style={styles.calendar} />
+                                <Dropdown value={selectedItem} onChange={(e) => setSelectedItem(e.value)} options={items} optionLabel="name" optionValue="code" placeholder="Ascendente" className="w-full md:w-14rem" />
+                            </div>
+                        </Card>
+                        <br />
                         <DataTable
                             value={orders}
                             selectionMode="single"
@@ -238,8 +267,6 @@ const styles = {
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'space-between',
-        // backgroundColor: '#333',
-        // padding: '20px',
         paddingTop: '18px',
         borderRadius: '10px',
     },
@@ -249,17 +276,32 @@ const styles = {
         marginRight: '2%',
         justifyContent: 'center',
         overflowY: 'auto',
-        // backgroundColor: '#fff',
     },
     statusButtons: {
         display: 'flex',
         justifyContent: 'space-around',
     },
-    containerItems:{
-            width: '35%',
-            borderLeft: '3px solid #ccc',
-            paddingLeft: '2.5vh',
+    containerItems: {
+        width: '35%',
+        borderLeft: '3px solid #ccc',
+        paddingLeft: '2.5vh',
+    },
+    filterContainer: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',  // Adjust to align content horizontally
+        gap: '10px',  // Add some space between the elements if necessary
+    },
+    statusGroup: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '20px',  // Ensure sufficient space between radio buttons
+    },
+    calendar: {
+        marginLeft: '200px', 
+    },
+    ml2: {
+        marginLeft: '8px',
     }
 };
-
 export default withAuth(OrdersPage);

--- a/src/pages/kitchen/order.js
+++ b/src/pages/kitchen/order.js
@@ -59,7 +59,6 @@ function OrdersPage() {
 
     useEffect(() => {
         if (authToken) {
-            console.log("dates", dates);
             const selectedDates = dates ? dates : getCurrentDayRange();  // Usa las fechas seleccionadas o el rango del día actual por defecto
             const formattedDates = [
                 formatDate(new Date(selectedDates[0]), true),  // Formatea el startDate (00:00:00)
@@ -76,8 +75,14 @@ function OrdersPage() {
         if (isLastPage) {
             pollingInterval = setInterval(() => {
                 console.log('Polling on last page...');
-                //TODO:AGREGAR EL TOKEN
-                loadOrders(first / rows);
+                const selectedDates = dates ? dates : getCurrentDayRange();  // Usa las fechas seleccionadas o el rango del día actual por defecto
+                const formattedDates = [
+                    formatDate(new Date(selectedDates[0]), true),  // Formatea el startDate (00:00:00)
+                    formatDate(new Date(selectedDates[1]), false)  // Formatea el endDate (23:59:59)
+                ];
+        
+                console.log('Fechas a utilizar:', formattedDates);                
+                loadOrders(authToken, first / rows, formattedDates);
             }, 10000);  // Polling cada 10 segundos
 
             // Limpiamos el intervalo al salir de la última página o cuando el componente se desmonte
@@ -86,7 +91,7 @@ function OrdersPage() {
             // Si no estamos en la última página, limpiar cualquier intervalo de polling
             clearInterval(pollingInterval);
         }
-    }, [isLastPage, first, rows]);
+    }, [isLastPage, authToken, first, rows, status, dates, selectedItem]);
 
     const loadOrders = async (authToken, pageNumber, formattedDates = []) => {
         setLoading(true);

--- a/src/pages/kitchen/order.js
+++ b/src/pages/kitchen/order.js
@@ -27,7 +27,7 @@ function OrdersPage() {
     const [isLastPage, setIsLastPage] = useState(false);  // Bandera para saber si estamos en la última página
     const [dates, setDates] = useState(null);  // Almacena las fechas seleccionadas
     const [status, setStatus] = useState('Pendiente'); 
-    const [selectedItem, setSelectedItem] = useState(null);
+    const [selectedItem, setSelectedItem] = useState("true");
     const items = [ {name: 'Ascendente', code: 'true'}, {name: 'Descendente', code: 'false'}];
     let pollingInterval = null;  // Variable para almacenar el intervalo del polling
 
@@ -38,7 +38,7 @@ function OrdersPage() {
         if (authToken) {  // Solo cargar si el token está disponible
             loadOrders(authToken,first / rows);  // Llamamos a loadOrders cuando cambian first o rows
         }
-    }, [first, rows, authToken,status]);
+    }, [first, rows, authToken, status, selectedItem]); //dates
 
     useEffect(() => {
         // Si estamos en la última página, iniciamos el polling
@@ -59,8 +59,9 @@ function OrdersPage() {
 
     const loadOrders = async (authToken, pageNumber) => {
         setLoading(true);
+        console.log("dates:", dates);
         try {
-            const data = await orderService.getOrdersByStatus(status, pageNumber, authToken); 
+            const data = await orderService.getOrdersByStatus(status, pageNumber, selectedItem, authToken); 
             // Evitar re-renderizar si no hay cambios en los datos
             if (JSON.stringify(data.content) !== JSON.stringify(orders)) {
                 setOrders(data.content);  // Solo actualizar si los datos son diferentes

--- a/src/pages/kitchen/order.js
+++ b/src/pages/kitchen/order.js
@@ -14,6 +14,7 @@ import { Dropdown } from 'primereact/dropdown';
 import OrderService from '@/service/OrderService';
 import withAuth from '@/components/misc/WithAuth';
 import { AuthContext } from '../../../context/AuthContext';
+import { map, padStart } from 'lodash';
 
 function OrdersPage() {
     const { authToken } = useContext(AuthContext);
@@ -29,16 +30,46 @@ function OrdersPage() {
     const [status, setStatus] = useState('Pendiente'); 
     const [selectedItem, setSelectedItem] = useState("true");
     const items = [ {name: 'Ascendente', code: 'true'}, {name: 'Descendente', code: 'false'}];
+    
     let pollingInterval = null;  // Variable para almacenar el intervalo del polling
 
     const orderService = new OrderService(); 
     const toast = useRef(null);
 
+    const getCurrentDayRange = () => {
+        const today = new Date();
+        const startOfDay = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0);
+        const endOfDay = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59);
+        return [startOfDay, endOfDay];
+    };
+
+    const formatDate = (date, isStartDate = true) => {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+    
+        // Si es startDate, ponemos la hora en 00:00:00, si es endDate, en 23:59:59
+        const hours = isStartDate ? '00' : '23';
+        const minutes = isStartDate ? '00' : '59';
+        const seconds = isStartDate ? '00' : '59';
+        
+        return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+    };
+    
+
     useEffect(() => {
-        if (authToken) {  // Solo cargar si el token está disponible
-            loadOrders(authToken,first / rows);  // Llamamos a loadOrders cuando cambian first o rows
+        if (authToken) {
+            console.log("dates", dates);
+            const selectedDates = dates ? dates : getCurrentDayRange();  // Usa las fechas seleccionadas o el rango del día actual por defecto
+            const formattedDates = [
+                formatDate(new Date(selectedDates[0]), true),  // Formatea el startDate (00:00:00)
+                formatDate(new Date(selectedDates[1]), false)  // Formatea el endDate (23:59:59)
+            ];
+    
+            console.log('Fechas a utilizar:', formattedDates);  // Debug para verificar el formato
+            loadOrders(authToken, first / rows, formattedDates);
         }
-    }, [first, rows, authToken, status, selectedItem]); //dates
+    }, [authToken, first, rows, status, dates, selectedItem]);
 
     useEffect(() => {
         // Si estamos en la última página, iniciamos el polling
@@ -57,11 +88,11 @@ function OrdersPage() {
         }
     }, [isLastPage, first, rows]);
 
-    const loadOrders = async (authToken, pageNumber) => {
+    const loadOrders = async (authToken, pageNumber, formattedDates = []) => {
         setLoading(true);
-        console.log("dates:", dates);
         try {
-            const data = await orderService.getOrdersByStatus(status, pageNumber, selectedItem, authToken); 
+            const [startDate, endDate] = formattedDates; // Supone que tienes un rango de fechas (opcional)
+            const data = await orderService.getOrdersByStatus(status, pageNumber, selectedItem, startDate, endDate, authToken); 
             // Evitar re-renderizar si no hay cambios en los datos
             if (JSON.stringify(data.content) !== JSON.stringify(orders)) {
                 setOrders(data.content);  // Solo actualizar si los datos son diferentes

--- a/src/service/OrderService.js
+++ b/src/service/OrderService.js
@@ -1,3 +1,4 @@
+
 export default class OrderService {
     constructor() {
         this.BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
@@ -27,11 +28,12 @@ export default class OrderService {
     }
     // Método para obtener las ordenes paginadas por estado
     //http://localhost:8080/api/v1/public/order/status?status=Cancelado&pageNumber=0
-    async getOrdersByStatus(status, pageNumber) {
+    async getOrdersByStatus(status, pageNumber, token) {
         try {
-            const response = await fetch(`${this.BASE_URL}/api/v1/public/order/status?status=${status}&pageNumber=${pageNumber}`, {
+            const response = await fetch(`${this.BASE_URL}/api/v1/order?status=${status}&pageNumber=${pageNumber}`, {
                 method: 'GET',
                 headers: {
+                    'Authorization':  `Bearer ${token}`,
                     'Content-Type': 'application/json',
                 }
             });

--- a/src/service/OrderService.js
+++ b/src/service/OrderService.js
@@ -28,9 +28,9 @@ export default class OrderService {
     }
     // Método para obtener las ordenes paginadas por estado
     //http://localhost:8080/api/v1/public/order/status?status=Cancelado&pageNumber=0
-    async getOrdersByStatus(status, pageNumber, token) {
+    async getOrdersByStatus(status, pageNumber, asc, token) {
         try {
-            const response = await fetch(`${this.BASE_URL}/api/v1/order?status=${status}&pageNumber=${pageNumber}`, {
+            const response = await fetch(`${this.BASE_URL}/api/v1/order?status=${status}&pageNumber=${pageNumber}&sortAscending=${asc}`, {
                 method: 'GET',
                 headers: {
                     'Authorization':  `Bearer ${token}`,

--- a/src/service/OrderService.js
+++ b/src/service/OrderService.js
@@ -28,9 +28,9 @@ export default class OrderService {
     }
     // Método para obtener las ordenes paginadas por estado
     //http://localhost:8080/api/v1/public/order/status?status=Cancelado&pageNumber=0
-    async getOrdersByStatus(status, pageNumber, asc, token) {
+    async getOrdersByStatus(status, pageNumber, asc, startDate, endDate, token) {
         try {
-            const response = await fetch(`${this.BASE_URL}/api/v1/order?status=${status}&pageNumber=${pageNumber}&sortAscending=${asc}`, {
+            const response = await fetch(`${this.BASE_URL}/api/v1/order?status=${status}&minDate=${startDate}&maxDate=${endDate}&pageNumber=${pageNumber}&sortAscending=${asc}`, {
                 method: 'GET',
                 headers: {
                     'Authorization':  `Bearer ${token}`,


### PR DESCRIPTION
Se realizaron los siguientes cambios:
- Se agregaron campos para filtrado en la vista web de ordenes
- Se agrego el filtrado por estado de pedido
- Se agrego filtrado descendente y ascendente
- Se agrego el filtrado por fecha (por defecto solo se ve el día actual)
- Se actualizo el polling con los cambios
- Se bloqueo el boton de "marcar como completado" en los casos de que el pedido estuviera "entregado" y "cancelado"