### PR TITLE
cambios para consumo eliminar platillo

### DIFF
--- a/context/MenuContext.js
+++ b/context/MenuContext.js
@@ -71,12 +71,33 @@ const MenuProvider = ({ children }) => {
         }
     };
 
+    const deleteMenuItem = async (menuItemId) => {
+        try {
+            const response = await menuService.deleteMenuItem(menuItemId, authToken);
+
+            if (response.responseCode === 'MEN-005') {
+                // Eliminar el elemento del estado solo si la respuesta es exitosa
+                setMenuItems(prevItems => prevItems.filter(item => item.id !== menuItemId));
+                console.log('Menu item deleted successfully.');
+                return 200; // Indica éxito
+            } else if (response.responseCode === 'MEN-409') {
+                // Muestra el mensaje de error si hay un conflicto
+                console.error(`Error: ${response.errorMessage}`);
+                return 409; // Indica conflicto
+            }
+        } catch (error) {
+            console.error('Error deleting menu item:', error);
+            return 500; // Indica error del servidor
+        }
+    };
+
     return (
         <MenuContext.Provider value={{ 
             menuItems,
             loadMenuItems,
             addMenuItem,
             changeMenuItemStatus,
+            deleteMenuItem,
             first,
             setFirst,
             rows,

--- a/src/components/menu/MenuItemSelected.js
+++ b/src/components/menu/MenuItemSelected.js
@@ -1,12 +1,59 @@
 // MenuItemSelected.js
-import React from 'react';
+import React, { useState, useContext , useRef, useEffect} from 'react';
+import { AuthContext } from '../../../context/AuthContext'; 
 import { Card } from 'primereact/card';
+import { MenuContext } from '../../../context/MenuContext';
+import { Toast } from 'primereact/toast';
+import { Button } from 'primereact/button';
+import { ConfirmDialog } from 'primereact/confirmdialog';
 
 const MenuItemSelected = ({ selectedItem }) => {
+    const { userRoles } = useContext(AuthContext); // Accede a los roles del usuario desde el contexto
+    const { deleteMenuItem } = useContext(MenuContext);
+    const toast = useRef(null);
+    const [visible, setVisible] = useState(false);
+
     if (!selectedItem) return null;
+
+    const showConfirmDialog = () => {
+        setVisible(true);
+    };
+
+    const onConfirm = async () => {
+        setVisible(false);
+        // Llamar a la función que maneja el consumo del endpoint
+        await handleDeleteMenuItem();
+    };
+
+    const onCancel = () => {
+        setVisible(false);
+    };
+
+    const handleDeleteMenuItem = async () => {
+        const response = await deleteMenuItem(selectedItem.id);
+
+        if (response == 200) {
+            toast.current.show({ severity: 'success', summary: 'Éxito', detail: 'Elemento del menú eliminado', life: 3000 });
+            return null;
+        } else if(response==409) {
+            toast.current.show({ severity: 'error', summary: 'Error', detail: 'No puede eliminar elementos del menú relacionados a órdenes', life: 3000 });
+        } else{
+            toast.current.show({ severity: 'error', summary: 'Error', detail: 'Error al eliminar el elemento del menú', life: 3000 });
+        }
+    };
 
     return (
         <div>
+            <Toast ref={toast} />
+            <ConfirmDialog
+                visible={visible}
+                onHide={onCancel}
+                message="¿Estás seguro de que deseas eliminar este platillo?"
+                header="Confirmación"
+                icon="pi pi-exclamation-triangle"
+                accept={onConfirm}
+                reject={onCancel}
+            />
             <Card title={`Detalles de ${selectedItem.name}`} style={styles.detailCard}></Card>
             <br />  
             <Card>
@@ -14,6 +61,18 @@ const MenuItemSelected = ({ selectedItem }) => {
                 <p><strong>Descripción:</strong> {selectedItem.description}</p>
                 <p><strong>Precio:</strong> {selectedItem.price} Bs.</p>
                 <p><strong>Estado:</strong> {selectedItem.status ? "Habilitado" : "Deshabilitado"}</p>
+                {userRoles.includes('administrator') && (
+                    <>
+                        <Button
+                            label="Eliminar"
+                            icon="pi pi-trash"
+                            className="p-button-danger"
+                            size="small"
+                            style={styles.enableButton}
+                            onClick={() => showConfirmDialog()}
+                        />
+                    </>
+                )}
             </Card>
         </div>
     );

--- a/src/service/MenuService.js
+++ b/src/service/MenuService.js
@@ -118,4 +118,23 @@ export default class MenuService {
             throw error;
         }
     }
+
+    async deleteMenuItem(menuItemId, token) {
+        try {
+            const response = await fetch(`${this.BASE_URL}/api/v1/menu/item/${menuItemId}`, {
+                method: 'DELETE',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json'
+                }
+            });
+            const data = await response.json();
+            console.log('Menu item deleted:', data);
+            return data;
+        } catch (error) {
+            console.error('Error deleting menu item:', error);
+            throw error;
+        }
+    }
 }


### PR DESCRIPTION
SCRUM 287: Consumir el endpoint de eliminar platillo en frontend web.

Se esta utilizando el context de menu.
Se hizo sobre la base de separacion de roles hecha.